### PR TITLE
fix(spa): repair client-side router and polish default theme

### DIFF
--- a/packages/bunpress/src/serve.ts
+++ b/packages/bunpress/src/serve.ts
@@ -39,12 +39,10 @@ async function generateSidebar(config: BunPressConfig, currentPath: string): Pro
   const sectionsHtml = await Promise.all(sidebarSections.map(async (section) => {
     const itemsHtml = section.items
       ? section.items.map((item: SidebarItem) => {
-          // Use the link as-is (no /docs/ prefix needed)
           const link = item.link || '/'
-
           const isActive = link === currentPath || item.link === currentPath
-          const activeStyle = isActive ? 'color: var(--bp-c-brand-1); font-weight: 500;' : ''
-          return `<li><a href="${link}" style="display: block; padding: 6px 24px; color: var(--bp-c-text-2); text-decoration: none; font-size: 14px; transition: color 0.25s; ${activeStyle}" onmouseover="this.style.color='var(--bp-c-brand-1)'" onmouseout="this.style.color='${isActive ? 'var(--bp-c-brand-1)' : 'var(--bp-c-text-2)'}'">${item.text}</a></li>`
+          const cls = isActive ? 'VPSidebarItem-link is-active' : 'VPSidebarItem-link'
+          return `<li><a class="${cls}" href="${link}">${item.text}</a></li>`
         }).join('')
       : ''
 
@@ -149,131 +147,299 @@ function injectSPARouter(html: string): string {
  * browser back/forward. No framework dependencies.
  */
 function generateSPARouterScript(): string {
-  return `<script>
+  return `<script data-bp-router="1">
 (function(){
-  var cache = {};
-  var parser = new DOMParser();
+  if (history.scrollRestoration) history.scrollRestoration = 'manual';
 
-  function isInternal(url) {
-    try {
-      var u = new URL(url, location.origin);
-      return u.origin === location.origin && !u.pathname.match(/\\.[a-z]+$/i);
-    } catch(e) { return false; }
+  var cache = Object.create(null);
+  var parser = new DOMParser();
+  var scrollPositions = Object.create(null);
+  var historyIndex = (history.state && typeof history.state.idx === 'number') ? history.state.idx : 0;
+  var lastPathname = location.pathname;
+  var lastSearch = location.search;
+
+  // Wrap pushState/replaceState so any caller (incl. inline scripts) gets a tracked idx
+  var origPush = history.pushState.bind(history);
+  var origReplace = history.replaceState.bind(history);
+  history.pushState = function(state, title, url) {
+    state = state || {};
+    if (typeof state.idx !== 'number') {
+      historyIndex++;
+      state.idx = historyIndex;
+    } else {
+      historyIndex = state.idx;
+    }
+    return origPush(state, title, url);
+  };
+  history.replaceState = function(state, title, url) {
+    state = state || {};
+    if (typeof state.idx !== 'number') state.idx = historyIndex;
+    else historyIndex = state.idx;
+    return origReplace(state, title, url);
+  };
+  if (!history.state || typeof history.state.idx !== 'number') {
+    origReplace({ idx: historyIndex }, '', location.href);
+  }
+
+  function getScroller() {
+    var el = document.querySelector('.VPContent');
+    if (el) {
+      var cs = getComputedStyle(el);
+      if (cs.position === 'fixed' && (cs.overflowY === 'auto' || cs.overflowY === 'scroll')) {
+        return el;
+      }
+    }
+    return window;
+  }
+
+  function readScroll() {
+    var s = getScroller();
+    return s === window ? window.scrollY : s.scrollTop;
+  }
+
+  function applyScroll(y) {
+    var s = getScroller();
+    if (s === window) window.scrollTo(0, y);
+    else s.scrollTop = y;
+  }
+
+  function saveScroll() {
+    scrollPositions[historyIndex] = readScroll();
+  }
+
+  function isInternalNavigable(u) {
+    return u.origin === location.origin && !u.pathname.match(/\\.[a-z]+$/i);
   }
 
   function updateActiveLinks() {
     var path = location.pathname;
+    document.querySelectorAll('a.is-active').forEach(function(a) {
+      a.classList.remove('is-active');
+    });
     document.querySelectorAll('a[href]').forEach(function(a) {
       var href = a.getAttribute('href');
-      if (href === path || (href !== '/' && path.startsWith(href))) {
-        a.style.color = 'var(--bp-c-brand-1)';
-        a.style.fontWeight = '500';
+      if (!href || href.startsWith('#')) return;
+      var u;
+      try { u = new URL(href, location.origin); } catch(_) { return; }
+      if (u.origin !== location.origin) return;
+      var p = u.pathname;
+      // eslint-disable-next-line general/prefer-template -- inner JS string; template literals would clash with the outer TS template
+      if (p === path || (p !== '/' && (path === p || path.startsWith(p + '/')))) {
+        a.classList.add('is-active');
       }
     });
   }
 
-  async function navigate(url, push) {
-    if (push !== false) history.pushState(null, '', url);
+  function executeScripts(root) {
+    if (!root) return;
+    root.querySelectorAll('script').forEach(function(s) {
+      if (s.dataset && s.dataset.bpRouter) return;
+      var ns = document.createElement('script');
+      for (var i = 0; i < s.attributes.length; i++) {
+        var attr = s.attributes[i];
+        ns.setAttribute(attr.name, attr.value);
+      }
+      if (!s.src) ns.textContent = s.textContent;
+      s.parentNode.replaceChild(ns, s);
+    });
+  }
 
-    var html = cache[url];
+  function scrollToHash(hash) {
+    if (!hash) return false;
+    var id;
+    try { id = decodeURIComponent(hash.slice(1)); } catch(_) { id = hash.slice(1); }
+    if (!id) return false;
+    var el = document.getElementById(id);
+    if (!el) {
+      try { el = document.querySelector('[name="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]'); } catch(_) {}
+    }
+    if (el) {
+      el.scrollIntoView({ behavior: 'auto', block: 'start' });
+      return true;
+    }
+    return false;
+  }
+
+  function detectLayout(root) {
+    if (root.querySelector('.VPHome')) return 'home';
+    if (root.querySelector('.VPContent--doc') || root.querySelector('.VPSidebar')) return 'doc';
+    if (root.querySelector('.VPContent--page') || root.querySelector('.VPPage')) return 'page';
+    return 'page';
+  }
+
+  async function navigate(href, opts) {
+    opts = opts || {};
+    var target = new URL(href, location.origin);
+    var key = target.pathname + target.search;
+
+    if (opts.push) {
+      saveScroll();
+      history.pushState({}, '', target.pathname + target.search + target.hash);
+    }
+
+    var html = cache[key];
     if (!html) {
       try {
-        var res = await fetch(url);
+        var res = await fetch(key, { headers: { 'X-BP-SPA': '1' } });
+        if (!res.ok) {
+          // 404 / 5xx — fall through to a real navigation so the browser shows the actual error page
+          location.href = target.href;
+          return;
+        }
         html = await res.text();
-        cache[url] = html;
-      } catch(e) {
-        location.href = url;
+        cache[key] = html;
+      } catch(_) {
+        location.href = target.href;
         return;
       }
     }
 
     var doc = parser.parseFromString(html, 'text/html');
 
-    // Update title
     var newTitle = doc.querySelector('title');
     if (newTitle) document.title = newTitle.textContent;
 
-    // Update meta description
-    var newDesc = doc.querySelector('meta[name="description"]');
-    var curDesc = document.querySelector('meta[name="description"]');
-    if (newDesc && curDesc) curDesc.setAttribute('content', newDesc.getAttribute('content'));
+    // Sync description, og:*, twitter:* meta tags
+    doc.querySelectorAll('meta[name="description"], meta[property^="og:"], meta[name^="twitter:"]').forEach(function(nm) {
+      var sel;
+      if (nm.getAttribute('property')) sel = 'meta[property="' + nm.getAttribute('property') + '"]';
+      else sel = 'meta[name="' + nm.getAttribute('name') + '"]';
+      var existing = document.querySelector(sel);
+      if (existing) existing.setAttribute('content', nm.getAttribute('content') || '');
+      else document.head.appendChild(nm.cloneNode(true));
+    });
+    var newCanonical = doc.querySelector('link[rel="canonical"]');
+    var curCanonical = document.querySelector('link[rel="canonical"]');
+    if (newCanonical && curCanonical) curCanonical.setAttribute('href', newCanonical.getAttribute('href') || '');
+    else if (newCanonical && !curCanonical) document.head.appendChild(newCanonical.cloneNode(true));
 
-    // Detect layout type: home vs doc vs page
-    var curLayout = document.querySelector('.VPHome') ? 'home' : (document.querySelector('.VPContent') ? 'doc' : 'page');
-    var newLayout = doc.querySelector('.VPHome') ? 'home' : (doc.querySelector('.VPContent') ? 'doc' : 'page');
+    var curLayout = detectLayout(document);
+    var newLayout = detectLayout(doc);
 
     if (curLayout !== newLayout) {
-      // Layout changed — full body swap
       document.body.innerHTML = doc.body.innerHTML;
-      // Re-execute scripts so sidebar toggle, theme toggle etc. work
-      doc.body.querySelectorAll('script').forEach(function(s) {
-        var ns = document.createElement('script');
-        if (s.src) ns.src = s.src; else ns.textContent = s.textContent;
-        document.body.appendChild(ns);
-      });
+      executeScripts(document.body);
+    } else if (curLayout === 'home') {
+      var newHome = doc.querySelector('.VPHome');
+      var curHome = document.querySelector('.VPHome');
+      if (newHome && curHome) {
+        curHome.innerHTML = newHome.innerHTML;
+        executeScripts(curHome);
+      }
+    } else if (curLayout === 'doc') {
+      var newMain = doc.querySelector('.VPDoc');
+      var curMain = document.querySelector('.VPDoc');
+      if (newMain && curMain) {
+        curMain.innerHTML = newMain.innerHTML;
+        executeScripts(curMain);
+      }
+      var newSidebar = doc.querySelector('.VPSidebar');
+      var curSidebar = document.querySelector('.VPSidebar');
+      if (newSidebar && curSidebar) {
+        curSidebar.innerHTML = newSidebar.innerHTML;
+        executeScripts(curSidebar);
+      }
+      var newAside = doc.querySelector('.VPDocAside');
+      var curAside = document.querySelector('.VPDocAside');
+      if (newAside && curAside) {
+        curAside.innerHTML = newAside.innerHTML;
+        executeScripts(curAside);
+      }
     } else {
-      // Same layout — swap content + sidebar + TOC
-      if (curLayout === 'home') {
-        var newHome = doc.querySelector('.VPHome');
-        var curHome = document.querySelector('.VPHome');
-        if (newHome && curHome) curHome.innerHTML = newHome.innerHTML;
-      } else {
-        // Doc/page layout: swap content area
-        var newMain = doc.querySelector('.VPDoc') || doc.querySelector('main');
-        var curMain = document.querySelector('.VPDoc') || document.querySelector('main');
-        if (newMain && curMain) curMain.innerHTML = newMain.innerHTML;
-
-        // Update sidebar
-        var newSidebar = doc.querySelector('.VPSidebar');
-        var curSidebar = document.querySelector('.VPSidebar');
-        if (newSidebar && curSidebar) curSidebar.innerHTML = newSidebar.innerHTML;
-
-        // Update TOC
-        var newToc = doc.querySelector('.VPDocAside');
-        var curToc = document.querySelector('.VPDocAside');
-        if (newToc && curToc) curToc.innerHTML = newToc.innerHTML;
+      // page layout
+      var newPage = doc.querySelector('.VPPage') || doc.querySelector('.VPContent');
+      var curPage = document.querySelector('.VPPage') || document.querySelector('.VPContent');
+      if (newPage && curPage) {
+        curPage.innerHTML = newPage.innerHTML;
+        executeScripts(curPage);
       }
     }
 
-    // Update <style> tags (CSS may differ between pages)
     var newStyles = doc.querySelectorAll('style[data-crosswind]');
-    var curStyles = document.querySelectorAll('style[data-crosswind]');
-    if (newStyles.length && curStyles.length) {
-      curStyles.forEach(function(s) { s.remove(); });
+    if (newStyles.length) {
+      document.querySelectorAll('style[data-crosswind]').forEach(function(s) { s.remove(); });
       newStyles.forEach(function(s) { document.head.appendChild(s.cloneNode(true)); });
     }
 
+    lastPathname = target.pathname;
+    lastSearch = target.search;
     updateActiveLinks();
-    window.scrollTo(0, 0);
+
+    if (typeof opts.restoreScroll === 'number') {
+      applyScroll(opts.restoreScroll);
+    } else if (target.hash) {
+      if (!scrollToHash(target.hash)) {
+        requestAnimationFrame(function(){ scrollToHash(target.hash); });
+      }
+    } else {
+      applyScroll(0);
+    }
   }
 
-  // Intercept clicks on internal links
   document.addEventListener('click', function(e) {
+    if (e.defaultPrevented) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
     var a = e.target.closest('a[href]');
     if (!a) return;
+    if (a.target && a.target !== '_self') return;
+    if (a.hasAttribute('download')) return;
+    var rel = a.getAttribute('rel') || '';
+    if (/\\bexternal\\b/.test(rel)) return;
     var href = a.getAttribute('href');
-    if (!href || href.startsWith('#') || a.target === '_blank') return;
-    var url = new URL(href, location.origin);
-    if (!isInternal(href)) return;
+    if (!href || href.startsWith('#')) return;
+    var u;
+    try { u = new URL(href, location.origin); } catch(_) { return; }
+    if (!isInternalNavigable(u)) return;
+
     e.preventDefault();
-    if (url.pathname === location.pathname) return;
-    navigate(url.pathname);
+
+    if (u.pathname === location.pathname && u.search === location.search) {
+      // Same page; update hash + scroll without re-render
+      saveScroll();
+      if (u.hash) {
+        history.pushState({}, '', u.pathname + u.search + u.hash);
+        scrollToHash(u.hash);
+      } else {
+        history.pushState({}, '', u.pathname + u.search);
+        applyScroll(0);
+      }
+      lastPathname = u.pathname;
+      lastSearch = u.search;
+      return;
+    }
+    navigate(u.href, { push: true });
   });
 
-  // Handle back/forward
-  window.addEventListener('popstate', function() {
-    navigate(location.pathname, false);
+  window.addEventListener('popstate', function(e) {
+    var newIdx = (e.state && typeof e.state.idx === 'number') ? e.state.idx : historyIndex;
+    var savedScroll = scrollPositions[newIdx];
+    saveScroll(); // capture scroll for the page being left, under the *current* historyIndex
+    historyIndex = newIdx;
+
+    if (location.pathname === lastPathname && location.search === lastSearch) {
+      // Hash-only or no-op change — skip re-render
+      if (typeof savedScroll === 'number') applyScroll(savedScroll);
+      else if (location.hash) { if (!scrollToHash(location.hash)) applyScroll(0); }
+      else applyScroll(0);
+      return;
+    }
+    navigate(location.href, { push: false, restoreScroll: typeof savedScroll === 'number' ? savedScroll : 0 });
   });
 
-  // Prefetch on hover
   document.addEventListener('mouseover', function(e) {
     var a = e.target.closest('a[href]');
     if (!a) return;
     var href = a.getAttribute('href');
-    if (href && isInternal(href) && !cache[href]) {
-      fetch(href).then(function(r) { return r.text(); }).then(function(h) { cache[href] = h; }).catch(function(){});
-    }
+    if (!href || href.startsWith('#')) return;
+    var u;
+    try { u = new URL(href, location.origin); } catch(_) { return; }
+    if (!isInternalNavigable(u)) return;
+    var key = u.pathname + u.search;
+    if (cache[key]) return;
+    fetch(key).then(function(r){ return r.ok ? r.text() : null; }).then(function(h){ if (h) cache[key] = h; }).catch(function(){});
   });
+
+  window.addEventListener('beforeunload', saveScroll);
 
   updateActiveLinks();
 })();
@@ -298,25 +464,22 @@ function generateNav(config: BunPressConfig): string {
   }
 
   const links = navConfig.map((item) => {
-    // Handle items with sub-items (dropdown)
     if (item.items && item.items.length > 0) {
-      return `<div class="relative group">
-        <button class="flex gap-1 items-center font-medium text-[#213547] text-[14px] hover:text-[#5672cd] transition-colors cursor-pointer">
-          ${item.text}
-          <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      return `<div class="VPNavBarMenu-group">
+        <button class="VPNavBarMenu-group-button" type="button">
+          <span>${item.text}</span>
+          <svg class="chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
           </svg>
         </button>
-        <div class="hidden group-hover:block absolute right-0 top-full mt-2 py-2 min-w-[160px] bg-white border border-[#e2e2e3] rounded-lg shadow-lg">
+        <div class="VPNavBarMenu-group-items">
           ${item.items.map(subItem =>
-            `<a href="${fixNavLink(subItem.link)}" class="block px-4 py-2 text-[#213547] text-[13px] hover:text-[#5672cd] hover:bg-[#f6f6f7] transition-colors">${subItem.text}</a>`,
+            `<a href="${fixNavLink(subItem.link)}">${subItem.text}</a>`,
           ).join('')}
         </div>
       </div>`
     }
-    else {
-      return `<a href="${fixNavLink(item.link)}" class="font-medium text-[#213547] text-[14px] hover:text-[#5672cd] transition-colors">${item.text}</a>`
-    }
+    return `<a class="VPNavBarMenu-link" href="${fixNavLink(item.link)}">${item.text}</a>`
   }).join('')
 
   return links
@@ -777,25 +940,22 @@ async function generateHero(hero: any): Promise<string> {
     return ''
 
   const name = hero.name
-    ? `<p style="font-size: 20px; font-weight: 700; letter-spacing: -0.02em; line-height: 1.2; background: linear-gradient(135deg, #5672cd 0%, #8b9cf7 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; margin: 0 0 8px;">${hero.name}</p>`
+    ? `<p class="VPHero-name">${hero.name}</p>`
     : ''
   const text = hero.text
-    ? `<h1 style="font-size: 40px; font-weight: 800; letter-spacing: -0.02em; line-height: 1.1; color: var(--bp-c-text-1); margin: 0 0 8px;">${hero.text}</h1>`
+    ? `<h1 class="VPHero-text">${hero.text}</h1>`
     : ''
   const tagline = hero.tagline
-    ? `<p style="font-size: 18px; font-weight: 400; line-height: 1.6; color: var(--bp-c-text-2); margin: 12px 0 0;">${hero.tagline}</p>`
+    ? `<p class="VPHero-tagline">${hero.tagline}</p>`
     : ''
 
   let actions = ''
   if (hero.actions) {
     const actionButtons = hero.actions.map((action: any) => {
-      const isPrimary = action.theme === 'brand'
-      if (isPrimary) {
-        return `<a href="${action.link}" style="display: inline-block; padding: 10px 24px; font-size: 14px; font-weight: 600; color: #fff; background: #5672cd; border-radius: 20px; text-decoration: none; transition: background 0.25s; border: 1px solid transparent;" onmouseover="this.style.background='#4558b8'" onmouseout="this.style.background='#5672cd'">${action.text}</a>`
-      }
-      return `<a href="${action.link}" style="display: inline-block; padding: 10px 24px; font-size: 14px; font-weight: 600; color: var(--bp-c-text-1); background: transparent; border: 1px solid var(--bp-c-divider); border-radius: 20px; text-decoration: none; transition: border-color 0.25s;" onmouseover="this.style.borderColor='var(--bp-c-text-2)'" onmouseout="this.style.borderColor='var(--bp-c-divider)'">${action.text}</a>`
+      const cls = action.theme === 'brand' ? 'VPButton VPButton-brand' : 'VPButton VPButton-alt'
+      return `<a class="${cls}" href="${action.link}">${action.text}</a>`
     }).join('\n      ')
-    actions = `<div style="display: flex; flex-wrap: wrap; gap: 12px; margin-top: 28px;">${actionButtons}</div>`
+    actions = `<div class="VPHero-actions">${actionButtons}</div>`
   }
 
   const image = hero.image
@@ -831,7 +991,7 @@ function getFeatureIcon(icon: string): string {
   // If it's an emoji or HTML, pass through
   if (icon.startsWith('<') || /\p{Emoji}/u.test(icon)) return icon
   // Check icon map
-  return featureIconMap[icon] || `<span style="font-size: 24px; font-weight: 700;">${icon.charAt(0)}</span>`
+  return featureIconMap[icon] || `<span class="VPFeature-icon-text">${icon.charAt(0)}</span>`
 }
 
 async function generateFeatures(features: any[]): Promise<string> {
@@ -840,15 +1000,16 @@ async function generateFeatures(features: any[]): Promise<string> {
 
   const items = features.map(feature => {
     const icon = feature.icon ? getFeatureIcon(feature.icon) : ''
-    const iconHtml = icon
-      ? `<div style="width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; border-radius: 8px; background: rgba(86, 114, 205, 0.1); color: #5672cd; margin-bottom: 12px;">${icon}</div>`
-      : ''
+    const iconHtml = icon ? `<div class="VPFeature-icon">${icon}</div>` : ''
+    const link = feature.link
+    const tag = link ? 'a' : 'div'
+    const linkAttr = link ? ` href="${link}"` : ''
     return `
-    <div style="padding: 24px; background: var(--bp-c-bg-soft, var(--bp-c-bg-alt)); border: 1px solid var(--bp-c-divider); border-radius: 12px; transition: border-color 0.25s, box-shadow 0.25s;" onmouseover="this.style.borderColor='#5672cd';this.style.boxShadow='0 2px 12px rgba(86,114,205,0.08)'" onmouseout="this.style.borderColor='var(--bp-c-divider)';this.style.boxShadow='none'">
+    <${tag} class="VPFeature"${linkAttr}>
       ${iconHtml}
-      <h3 style="margin: 0 0 8px; font-size: 16px; font-weight: 600; color: var(--bp-c-text-1);">${feature.title || ''}</h3>
-      <p style="margin: 0; font-size: 14px; line-height: 1.6; color: var(--bp-c-text-2);">${feature.details || ''}</p>
-    </div>`
+      <h3 class="VPFeature-title">${feature.title || ''}</h3>
+      <p class="VPFeature-details">${feature.details || ''}</p>
+    </${tag}>`
   }).join('')
 
   return await render('features', {
@@ -1106,24 +1267,11 @@ function processBadges(content: string): string {
   const badgeRegex = /<Badge([^/>]+)\/>/gi
 
   return content.replace(badgeRegex, (_match, attributes) => {
-    // Extract type and text attributes
     const typeMatch = attributes.match(/type="(info|tip|warning|danger)"/i)
     const textMatch = attributes.match(/text="([^"]+)"/)
-
     const type = typeMatch ? typeMatch[1].toLowerCase() : 'info'
     const text = textMatch ? textMatch[1] : ''
-
-    // Badge color schemes matching VitePress
-    const colors: Record<string, { bg: string, text: string, border: string }> = {
-      info: { bg: '#e0f2fe', text: '#0c4a6e', border: '#0ea5e9' },
-      tip: { bg: '#dcfce7', text: '#14532d', border: '#22c55e' },
-      warning: { bg: '#fef3c7', text: '#78350f', border: '#f59e0b' },
-      danger: { bg: '#fee2e2', text: '#7f1d1d', border: '#ef4444' },
-    }
-
-    const color = colors[type] || colors.info
-
-    return `<span class="badge badge-${type}" style="display: inline-block; padding: 2px 8px; font-size: 0.85em; font-weight: 600; border-radius: 4px; background: ${color.bg}; color: ${color.text}; border: 1px solid ${color.border}; margin: 0 4px; vertical-align: middle;">${text}</span>`
+    return `<span class="bp-badge bp-badge-${type}">${text}</span>`
   })
 }
 
@@ -1161,7 +1309,7 @@ function addExternalLinkIcons(html: string): string {
     if (match.includes('external-link-icon'))
       return match
 
-    const externalIcon = '<svg class="external-link-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: inline-block; margin-left: 4px; vertical-align: middle;"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>'
+    const externalIcon = '<svg class="external-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>'
     return match.replace('</a>', `${externalIcon}</a>`)
   })
 }

--- a/packages/bunpress/src/templates/features.stx
+++ b/packages/bunpress/src/templates/features.stx
@@ -1,20 +1,7 @@
-<div class="VPHomeFeatures" style="padding: 64px 24px; border-top: 1px solid var(--bp-c-divider);">
-  <div style="max-width: 1152px; margin: 0 auto;">
-    <div class="VPFeatures" style="display: grid; grid-template-columns: repeat(1, 1fr); gap: 24px;">
+<div class="VPHomeFeatures">
+  <div class="VPHomeFeatures-inner">
+    <div class="VPFeatures">
       {!! items !!}
     </div>
   </div>
 </div>
-
-<style>
-@media (min-width: 640px) {
-  .VPFeatures {
-    grid-template-columns: repeat(2, 1fr) !important;
-  }
-}
-@media (min-width: 960px) {
-  .VPFeatures {
-    grid-template-columns: repeat(3, 1fr) !important;
-  }
-}
-</style>

--- a/packages/bunpress/src/templates/layout-doc.stx
+++ b/packages/bunpress/src/templates/layout-doc.stx
@@ -14,25 +14,29 @@
 <body>
   <div class="Layout">
     <!-- VPNav - Header -->
-    <header class="VPNav" style="position: fixed; top: 0; left: 0; right: 0; height: var(--bp-nav-height, 64px); background-color: var(--bp-nav-bg-color, var(--bp-c-bg)); border-bottom: 1px solid var(--bp-c-divider); z-index: var(--bp-z-index-nav, 30);">
-      <div style="max-width: var(--bp-layout-max-width, 1440px); margin: 0 auto; width: 100%; height: 100%; display: flex; align-items: center; justify-content: space-between; padding: 0 24px;">
-        <!-- Left side: Logo/Title + Search -->
-        <div style="display: flex; align-items: center; gap: 24px; flex: 1; min-width: 0;">
-          <a href="/" class="VPNavBarTitle" style="font-size: 16px; font-weight: 600; color: var(--bp-c-text-1); white-space: nowrap; text-decoration: none;">{{ title }}</a>
-          <div class="VPNavBarSearch" style="position: relative; display: flex; align-items: center; max-width: 260px; width: 100%;">
-            <svg style="position: absolute; left: 12px; width: 16px; height: 16px; color: var(--bp-c-text-3);" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <header class="VPNav">
+      <div class="VPNavBar">
+        <div class="VPNavBarStart">
+          <button class="VPNavBarHamburger" type="button" aria-label="Toggle navigation" onclick="toggleSidebar()">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+            </svg>
+          </button>
+          <a href="/" class="VPNavBarTitle">{{ title }}</a>
+          <div class="VPNavBarSearch">
+            <svg class="VPNavBarSearch-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
             </svg>
-            <input type="text" placeholder="Search" style="width: 100%; height: 32px; padding-left: 36px; padding-right: 48px; font-size: 13px; background-color: var(--bp-c-bg-alt); border: 1px solid var(--bp-c-divider); border-radius: 4px; color: var(--bp-c-text-1); outline: none; transition: border-color 0.25s, background-color 0.25s;" />
-            <kbd style="position: absolute; right: 8px; padding: 2px 6px; font-size: 11px; font-weight: 600; color: var(--bp-c-text-3); background-color: var(--bp-c-bg); border: 1px solid var(--bp-c-divider); border-radius: 4px;">⌘ K</kbd>
+            <input type="text" class="VPNavBarSearch-input" placeholder="Search" />
+            <kbd class="VPNavBarSearch-kbd">⌘ K</kbd>
           </div>
         </div>
 
-        <!-- Right side: Navigation + Icons -->
-        <div style="display: flex; align-items: center; gap: 24px;">
-          {!! nav !!}
-          <div class="VPSocialLinks" style="display: flex; align-items: center; gap: 12px; padding-left: 24px; border-left: 1px solid var(--bp-c-divider);">
-            <!-- Theme Toggle -->
+        <div class="VPNavBarEnd">
+          <div class="VPNavBarMenu">
+            {!! nav !!}
+          </div>
+          <div class="VPSocialLinks">
             <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode" title="Toggle dark mode">
               <svg class="sun-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path>
@@ -41,8 +45,8 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
               </svg>
             </button>
-            <a href="https://github.com/stacksjs/bunpress" target="_blank" style="color: var(--bp-c-text-2); transition: color 0.25s;" onmouseover="this.style.color='var(--bp-c-text-1)'" onmouseout="this.style.color='var(--bp-c-text-2)'">
-              <svg style="width: 20px; height: 20px;" fill="currentColor" viewBox="0 0 24 24">
+            <a href="https://github.com/stacksjs/bunpress" target="_blank" rel="noopener external" aria-label="GitHub">
+              <svg fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
               </svg>
             </a>
@@ -55,9 +59,9 @@
     {!! sidebar !!}
 
     <!-- VPContent - Main content area -->
-    <main class="VPContent" style="position: fixed; top: var(--bp-nav-height, 64px); bottom: 0; overflow-y: auto; left: max(var(--bp-sidebar-width, 272px), calc((100vw - var(--bp-layout-max-width, 1440px)) / 2 + var(--bp-sidebar-width, 272px))); right: max(0px, calc((100vw - var(--bp-layout-max-width, 1440px)) / 2));">
-      <div class="VPDoc" style="padding: 32px 24px; padding-right: 32px;">
-        <div class="VPDocContent" style="max-width: 768px; margin: 0;">
+    <main class="VPContent VPContent--doc">
+      <div class="VPDoc">
+        <div class="VPDocContent">
           <article class="bp-doc">
             {!! content !!}
           </article>

--- a/packages/bunpress/src/templates/layout-page.stx
+++ b/packages/bunpress/src/templates/layout-page.stx
@@ -14,20 +14,22 @@
 <body>
   <div class="Layout">
     <!-- VPNav - Header -->
-    <header class="VPNav" style="position: fixed; top: 0; left: 0; right: 0; height: var(--bp-nav-height, 64px); background-color: var(--bp-nav-bg-color, var(--bp-c-bg)); border-bottom: 1px solid var(--bp-c-divider); z-index: var(--bp-z-index-nav, 30);">
-      <div style="max-width: var(--bp-layout-max-width, 1440px); margin: 0 auto; width: 100%; height: 100%; display: flex; align-items: center; justify-content: space-between; padding: 0 24px;">
-        <div style="display: flex; align-items: center; gap: 24px; flex: 1; min-width: 0;">
-          <a href="/" class="VPNavBarTitle" style="font-size: 16px; font-weight: 600; color: var(--bp-c-text-1); white-space: nowrap; text-decoration: none;">{{ title }}</a>
+    <header class="VPNav">
+      <div class="VPNavBar">
+        <div class="VPNavBarStart">
+          <a href="/" class="VPNavBarTitle">{{ title }}</a>
         </div>
-        <div style="display: flex; align-items: center; gap: 24px;">
-          {!! nav !!}
+        <div class="VPNavBarEnd">
+          <div class="VPNavBarMenu">
+            {!! nav !!}
+          </div>
         </div>
       </div>
     </header>
 
     <!-- VPContent - Full-width content without sidebar -->
-    <main class="VPContent" style="padding-top: var(--bp-nav-height, 64px);">
-      <div class="VPPage" style="padding: 48px 24px; max-width: 768px; margin: 0 auto;">
+    <main class="VPContent VPContent--page">
+      <div class="VPPage">
         <article class="bp-doc">
           {!! content !!}
         </article>

--- a/packages/bunpress/src/templates/page-toc.stx
+++ b/packages/bunpress/src/templates/page-toc.stx
@@ -234,6 +234,11 @@ function initPageTOC() {
   });
 
   // Listen to scroll events on the actual scrolling container
+  // Remove any prior listener first so SPA navigation doesn't stack duplicates
+  if (scrollContainer.__bpTocScroll) {
+    scrollContainer.removeEventListener('scroll', scrollContainer.__bpTocScroll);
+  }
+  scrollContainer.__bpTocScroll = onScroll;
   scrollContainer.addEventListener('scroll', onScroll);
 
   // Handle URL hash on page load

--- a/packages/bunpress/src/templates/sidebar-section.stx
+++ b/packages/bunpress/src/templates/sidebar-section.stx
@@ -1,27 +1,60 @@
-<div class="VPSidebarItem sidebar-section" style="margin-bottom: 16px;">
-  <button
-    style="width: 100%; display: flex; align-items: center; justify-content: space-between; padding: 8px 24px; font-size: 14px; font-weight: 600; color: var(--bp-c-text-1); background: transparent; border: none; cursor: pointer; transition: color 0.25s;"
-    onclick="toggleSection(this.parentElement)"
-    onmouseover="this.style.color='var(--bp-c-brand-1)'"
-    onmouseout="this.style.color='var(--bp-c-text-1)'"
-  >
+<div class="VPSidebarItem sidebar-section">
+  <button class="sidebar-section-toggle" onclick="toggleSection(this.parentElement)" type="button">
     <span>{{ title }}</span>
-    <svg class="chevron" style="width: 16px; height: 16px; transition: transform 0.2s ease-in-out;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg class="chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="sidebar-items-wrapper">
-    <ul class="sidebar-items" style="list-style: none; margin: 4px 0 0 0; padding: 0;">
+    <ul class="sidebar-items">
       {!! items !!}
     </ul>
   </div>
 </div>
 
 <style>
+.sidebar-section {
+  margin-bottom: 16px;
+}
+
+.sidebar-section-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 24px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--bp-c-text-1);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: color 0.25s;
+  font-family: inherit;
+  text-align: left;
+}
+
+.sidebar-section-toggle:hover {
+  color: var(--bp-c-brand-1);
+}
+
+.sidebar-section-toggle .chevron {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.2s ease-in-out;
+  flex-shrink: 0;
+}
+
+.sidebar-items {
+  list-style: none;
+  margin: 4px 0 0 0;
+  padding: 0;
+}
+
 .sidebar-items-wrapper {
   overflow: hidden;
   transition: max-height 0.3s ease-in-out, opacity 0.2s ease-in-out;
-  max-height: 500px;
+  max-height: 1000px;
   opacity: 1;
 }
 
@@ -30,8 +63,31 @@
   opacity: 0;
 }
 
-.sidebar-section.collapsed .chevron {
+.sidebar-section.collapsed .sidebar-section-toggle .chevron {
   transform: rotate(-90deg);
+}
+
+.VPSidebarItem-link {
+  display: block;
+  padding: 6px 24px;
+  color: var(--bp-c-text-2);
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 1.5;
+  transition: color 0.25s;
+  border-left: 2px solid transparent;
+  margin-left: 0;
+}
+
+.VPSidebarItem-link:hover {
+  color: var(--bp-c-brand-1);
+}
+
+.VPSidebarItem-link.is-active {
+  color: var(--bp-c-brand-1);
+  font-weight: 600;
+  border-left-color: var(--bp-c-brand-1);
+  padding-left: 22px;
 }
 </style>
 

--- a/packages/bunpress/src/templates/sidebar.stx
+++ b/packages/bunpress/src/templates/sidebar.stx
@@ -1,8 +1,30 @@
+<div class="VPSidebar-backdrop" onclick="toggleSidebar(false)"></div>
 <nav class="VPSidebar">
   <div class="sidebar-content">
     {!! sections !!}
   </div>
 </nav>
+
+<script>
+function toggleSidebar(forceState) {
+  var sb = document.querySelector('.VPSidebar');
+  var bd = document.querySelector('.VPSidebar-backdrop');
+  if (!sb) return;
+  var nextOpen = typeof forceState === 'boolean' ? forceState : !sb.classList.contains('is-open');
+  sb.classList.toggle('is-open', nextOpen);
+  if (bd) bd.classList.toggle('is-open', nextOpen);
+  document.body.style.overflow = nextOpen ? 'hidden' : '';
+}
+if (!window.__bpSidebarBound) {
+  window.__bpSidebarBound = true;
+  // Close drawer when the user clicks a sidebar link on mobile
+  document.addEventListener('click', function(e) {
+    if (window.matchMedia('(min-width: 960px)').matches) return;
+    var a = e.target.closest('.VPSidebar a');
+    if (a) toggleSidebar(false);
+  });
+}
+</script>
 
 <style>
 .VPSidebar {

--- a/packages/bunpress/src/themes/bun/index.ts
+++ b/packages/bunpress/src/themes/bun/index.ts
@@ -11,6 +11,8 @@
  * - Dark backgrounds: #0d0e11, #14151a, #282a36
  */
 
+import { layoutCSS } from '../vitepress'
+
 // CSS Variables - Exact values from bun.sh
 const varsCSS = `/**
  * Bun Theme for BunPress
@@ -2036,6 +2038,7 @@ export function getBunThemeCSS(): string {
 /* Colors extracted from bun.sh */
 ${varsCSS}
 ${baseCSS}
+${layoutCSS}
 ${customBlockCSS}
 ${codeGroupCSS}
 ${bunExtrasCSS}

--- a/packages/bunpress/src/themes/vitepress/index.ts
+++ b/packages/bunpress/src/themes/vitepress/index.ts
@@ -1901,6 +1901,645 @@ const codeGroupCSS = `/**
   border: none;
 }`
 
+// Layout / chrome styles — classes referenced by layout-doc.stx, layout-page.stx, layout-home.stx,
+// and the nav/sidebar generators in serve.ts. Keeps templates declarative and dark-mode aware.
+export const layoutCSS = `/**
+ * VitePress Theme for BunPress - Layout & Chrome
+ * -------------------------------------------------------------------------- */
+
+.Layout {
+  min-height: 100vh;
+}
+
+/* VPNav — top bar */
+.VPNav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--bp-nav-height, 64px);
+  background-color: var(--bp-nav-bg-color, var(--bp-c-bg));
+  border-bottom: 1px solid var(--bp-c-divider);
+  z-index: var(--bp-z-index-nav, 30);
+  backdrop-filter: saturate(50%) blur(8px);
+}
+
+.VPNavBar {
+  max-width: var(--bp-layout-max-width, 1440px);
+  margin: 0 auto;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  gap: 24px;
+}
+
+.VPNavBarStart {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex: 1;
+  min-width: 0;
+}
+
+.VPNavBarEnd {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-shrink: 0;
+}
+
+.VPNavBarTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--bp-c-text-1);
+  white-space: nowrap;
+  text-decoration: none;
+  transition: color 0.25s;
+}
+
+.VPNavBarTitle:hover {
+  color: var(--bp-c-brand-1);
+}
+
+.VPNavBarMenu {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.VPNavBarMenu a,
+.VPNavBarMenu .VPNavBarMenu-link {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--bp-c-text-1);
+  text-decoration: none;
+  transition: color 0.25s;
+  cursor: pointer;
+}
+
+.VPNavBarMenu a:hover,
+.VPNavBarMenu .VPNavBarMenu-link:hover,
+.VPNavBarMenu a.is-active {
+  color: var(--bp-c-brand-1);
+}
+
+.VPNavBarMenu-group {
+  position: relative;
+}
+
+.VPNavBarMenu-group-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--bp-c-text-1);
+  cursor: pointer;
+  transition: color 0.25s;
+}
+
+.VPNavBarMenu-group-button:hover {
+  color: var(--bp-c-brand-1);
+}
+
+.VPNavBarMenu-group-button .chevron {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  transition: transform 0.25s;
+}
+
+.VPNavBarMenu-group:hover > .VPNavBarMenu-group-button .chevron {
+  transform: rotate(180deg);
+}
+
+.VPNavBarMenu-group-items {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: 8px;
+  padding: 8px 0;
+  min-width: 192px;
+  background: var(--bp-c-bg);
+  border: 1px solid var(--bp-c-divider);
+  border-radius: 8px;
+  box-shadow: var(--bp-shadow-3, 0 12px 32px rgba(0, 0, 0, 0.1));
+  z-index: 10;
+}
+
+.VPNavBarMenu-group:hover > .VPNavBarMenu-group-items {
+  display: block;
+}
+
+.VPNavBarMenu-group-items a {
+  display: block;
+  padding: 6px 16px;
+  font-size: 13px;
+  color: var(--bp-c-text-1);
+  text-decoration: none;
+  transition: color 0.25s, background-color 0.25s;
+}
+
+.VPNavBarMenu-group-items a:hover {
+  color: var(--bp-c-brand-1);
+  background-color: var(--bp-c-bg-soft);
+}
+
+/* Search */
+.VPNavBarSearch {
+  position: relative;
+  display: flex;
+  align-items: center;
+  max-width: 260px;
+  width: 100%;
+}
+
+.VPNavBarSearch-icon {
+  position: absolute;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  color: var(--bp-c-text-3);
+  pointer-events: none;
+}
+
+.VPNavBarSearch-input {
+  width: 100%;
+  height: 32px;
+  padding: 0 48px 0 36px;
+  font: inherit;
+  font-size: 13px;
+  background-color: var(--bp-c-bg-alt);
+  border: 1px solid var(--bp-c-divider);
+  border-radius: 4px;
+  color: var(--bp-c-text-1);
+  outline: none;
+  transition: border-color 0.25s, background-color 0.25s;
+}
+
+.VPNavBarSearch-input::placeholder {
+  color: var(--bp-c-text-3);
+}
+
+.VPNavBarSearch-input:hover,
+.VPNavBarSearch-input:focus {
+  border-color: var(--bp-c-brand-1);
+  background-color: var(--bp-c-bg);
+}
+
+.VPNavBarSearch-kbd {
+  position: absolute;
+  right: 8px;
+  padding: 2px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--bp-c-text-3);
+  background-color: var(--bp-c-bg);
+  border: 1px solid var(--bp-c-divider);
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+/* Social/icon links cluster */
+.VPSocialLinks {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-left: 24px;
+  border-left: 1px solid var(--bp-c-divider);
+}
+
+.VPSocialLinks > a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  color: var(--bp-c-text-2);
+  border-radius: 4px;
+  transition: color 0.25s, background-color 0.25s;
+}
+
+.VPSocialLinks > a:hover {
+  color: var(--bp-c-text-1);
+  background-color: var(--bp-c-bg-soft);
+}
+
+.VPSocialLinks > a svg {
+  width: 20px;
+  height: 20px;
+}
+
+/* Content area */
+.VPContent {
+  flex: 1;
+}
+
+.VPContent--doc {
+  position: fixed;
+  top: var(--bp-nav-height, 64px);
+  bottom: 0;
+  overflow-y: auto;
+  left: max(var(--bp-sidebar-width, 272px), calc((100vw - var(--bp-layout-max-width, 1440px)) / 2 + var(--bp-sidebar-width, 272px)));
+  right: max(0px, calc((100vw - var(--bp-layout-max-width, 1440px)) / 2));
+}
+
+.VPContent--page {
+  padding-top: var(--bp-nav-height, 64px);
+}
+
+.VPDoc {
+  padding: 32px 24px;
+  padding-right: 32px;
+}
+
+@media (min-width: 1280px) {
+  .VPDoc {
+    padding: 48px 32px 128px;
+  }
+}
+
+.VPDocContent {
+  max-width: 768px;
+  margin: 0;
+}
+
+.VPPage {
+  padding: 48px 24px;
+  max-width: 768px;
+  margin: 0 auto;
+}
+
+@media (min-width: 1280px) {
+  .VPPage {
+    padding: 64px 32px;
+  }
+}
+
+/* Mobile sidebar drawer behaviour */
+@media (max-width: 959px) {
+  .VPNavBarSearch {
+    display: none;
+  }
+  .VPSocialLinks {
+    padding-left: 12px;
+    gap: 8px;
+  }
+  .VPNavBarMenu {
+    display: none;
+  }
+}
+
+/**
+ * Hero (home layout) — used by hero.stx + serve.ts generateHero
+ * -------------------------------------------------------------------------- */
+
+.VPHero-name {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin: 0 0 8px;
+  background: linear-gradient(135deg, var(--bp-c-brand-1, #5672cd) 0%, var(--bp-c-brand-2, #8b9cf7) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.VPHero-text {
+  font-size: 40px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: var(--bp-c-text-1);
+  margin: 0 0 8px;
+}
+
+.VPHero-tagline {
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 1.6;
+  color: var(--bp-c-text-2);
+  margin: 12px 0 0;
+}
+
+@media (min-width: 960px) {
+  .VPHero-name {
+    font-size: 24px;
+  }
+  .VPHero-text {
+    font-size: 56px;
+  }
+  .VPHero-tagline {
+    font-size: 20px;
+  }
+}
+
+.VPHero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.VPButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 24px;
+  height: 40px;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 20px;
+  text-decoration: none;
+  transition: background-color 0.25s, color 0.25s, border-color 0.25s;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.VPButton-brand {
+  color: var(--bp-button-brand-text, #fff);
+  background-color: var(--bp-c-brand-1);
+  border-color: var(--bp-c-brand-1);
+}
+
+.VPButton-brand:hover {
+  background-color: var(--bp-c-brand-2);
+  border-color: var(--bp-c-brand-2);
+}
+
+.VPButton-alt {
+  color: var(--bp-c-text-1);
+  background-color: transparent;
+  border-color: var(--bp-c-divider);
+}
+
+.VPButton-alt:hover {
+  border-color: var(--bp-c-text-2);
+  color: var(--bp-c-brand-1);
+}
+
+/**
+ * Features grid — used by features.stx + serve.ts generateFeatures
+ * -------------------------------------------------------------------------- */
+
+.VPHomeFeatures {
+  padding: 48px 24px;
+  border-top: 1px solid var(--bp-c-divider);
+}
+
+.VPHomeFeatures-inner {
+  max-width: 1152px;
+  margin: 0 auto;
+}
+
+.VPFeatures {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 16px;
+}
+
+@media (min-width: 640px) {
+  .VPFeatures {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+  }
+}
+
+@media (min-width: 960px) {
+  .VPHomeFeatures {
+    padding: 64px 32px;
+  }
+  .VPFeatures {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.VPFeature {
+  display: block;
+  padding: 24px;
+  background-color: var(--bp-c-bg-soft, var(--bp-c-bg-alt));
+  border: 1px solid var(--bp-c-divider);
+  border-radius: 12px;
+  transition: border-color 0.25s, box-shadow 0.25s;
+  text-decoration: none;
+  color: inherit;
+}
+
+.VPFeature:hover {
+  border-color: var(--bp-c-brand-1);
+  box-shadow: 0 2px 12px rgba(86, 114, 205, 0.08);
+}
+
+.VPFeature-icon {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--bp-c-brand-soft, rgba(86, 114, 205, 0.1));
+  color: var(--bp-c-brand-1);
+  margin-bottom: 12px;
+}
+
+.VPFeature-icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.VPFeature-icon-text {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.VPFeature-title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--bp-c-text-1);
+}
+
+.VPFeature-details {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--bp-c-text-2);
+}
+
+/**
+ * Inline content — badges, external link icons
+ * -------------------------------------------------------------------------- */
+
+.bp-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 0.85em;
+  font-weight: 600;
+  border-radius: 4px;
+  margin: 0 4px;
+  vertical-align: middle;
+  border: 1px solid transparent;
+  line-height: 1.5;
+}
+
+.bp-badge-tip {
+  background: var(--bp-c-tip-soft, rgba(16, 185, 129, 0.14));
+  color: var(--bp-c-tip-1, var(--bp-c-green-1));
+  border-color: var(--bp-c-tip-2, var(--bp-c-green-2));
+}
+
+.bp-badge-info {
+  background: var(--bp-c-default-soft, var(--bp-c-gray-soft));
+  color: var(--bp-c-text-1);
+  border-color: var(--bp-c-divider);
+}
+
+.bp-badge-warning {
+  background: var(--bp-c-warning-soft, rgba(234, 179, 8, 0.14));
+  color: var(--bp-c-warning-1, var(--bp-c-yellow-1));
+  border-color: var(--bp-c-warning-2, var(--bp-c-yellow-2));
+}
+
+.bp-badge-danger {
+  background: var(--bp-c-danger-soft, rgba(244, 63, 94, 0.14));
+  color: var(--bp-c-danger-1, var(--bp-c-red-1));
+  border-color: var(--bp-c-danger-2, var(--bp-c-red-2));
+}
+
+.external-link-icon {
+  display: inline-block;
+  margin-left: 4px;
+  vertical-align: middle;
+  width: 12px;
+  height: 12px;
+}
+
+/**
+ * Polish: prose elements
+ * -------------------------------------------------------------------------- */
+
+/* Subtle row hover on tables */
+.bp-doc tr:hover {
+  background-color: var(--bp-c-bg-soft);
+}
+
+/* Mobile-safe table scroll */
+.bp-doc table {
+  width: 100%;
+  max-width: 100%;
+}
+
+/* Slightly stronger blockquote with brand-tinted accent */
+.bp-doc blockquote {
+  border-left-color: var(--bp-c-brand-1);
+  padding: 8px 0 8px 16px;
+}
+
+/* Code-block scrollbar */
+.bp-doc [class*='language-'] pre::-webkit-scrollbar,
+.bp-doc pre[data-lang]::-webkit-scrollbar {
+  height: 6px;
+  width: 6px;
+}
+.bp-doc [class*='language-'] pre::-webkit-scrollbar-thumb,
+.bp-doc pre[data-lang]::-webkit-scrollbar-thumb {
+  background-color: var(--bp-c-divider);
+  border-radius: 3px;
+}
+.bp-doc [class*='language-'] pre::-webkit-scrollbar-thumb:hover,
+.bp-doc pre[data-lang]::-webkit-scrollbar-thumb:hover {
+  background-color: var(--bp-c-text-3);
+}
+
+/* Heading anchor: keep it subtle */
+.bp-doc .header-anchor {
+  color: var(--bp-c-text-3);
+}
+.bp-doc .header-anchor:hover,
+.bp-doc .header-anchor:focus {
+  color: var(--bp-c-brand-1);
+}
+
+/**
+ * Mobile nav / sidebar drawer
+ * -------------------------------------------------------------------------- */
+
+.VPNavBarHamburger {
+  display: none;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  color: var(--bp-c-text-2);
+  border-radius: 4px;
+  padding: 0;
+  margin-left: -4px;
+}
+
+.VPNavBarHamburger:hover {
+  color: var(--bp-c-text-1);
+  background-color: var(--bp-c-bg-soft);
+}
+
+.VPNavBarHamburger svg {
+  width: 20px;
+  height: 20px;
+}
+
+@media (max-width: 959px) {
+  .VPNavBarHamburger {
+    display: inline-flex;
+  }
+
+  .VPSidebar {
+    transform: translateX(-100%);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    z-index: var(--bp-z-index-sidebar, 25);
+    background-color: var(--bp-c-bg-alt);
+    box-shadow: none;
+  }
+
+  .VPSidebar.is-open {
+    transform: translateX(0);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  }
+
+  .VPSidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.32);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: calc(var(--bp-z-index-sidebar, 25) - 1);
+  }
+
+  .VPSidebar-backdrop.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .VPContent--doc {
+    left: 0;
+  }
+}
+`
+
 /**
  * Get all VitePress theme CSS combined
  */
@@ -1909,6 +2548,7 @@ export function getVitePressThemeCSS(): string {
 /* VitePress Theme for BunPress */
 ${varsCSS}
 ${baseCSS}
+${layoutCSS}
 ${customBlockCSS}
 ${codeGroupCSS}
 `


### PR DESCRIPTION
## Summary
- Rewrites the SPA router in `serve.ts` so internal navigation handles cross-page hash anchors, browser back/forward scroll restoration, layout switches, and inline-script re-execution correctly. Layout is detected via new `VPContent--doc` / `VPContent--page` modifiers; scroll uses the active scroll container (the doc layout's `position:fixed` `.VPContent`) instead of the window. Closes #70.
- Polishes the default theme: 41 inline `style="..."` attributes across the layout templates are replaced with VitePress-style classes; chrome CSS (nav, sidebar, hero, features, buttons, badges, mobile drawer with hamburger + backdrop + body-scroll lock, code-block scrollbar, table hover, blockquote brand accent) is consolidated into a new exported `layoutCSS` chunk shared by both the `vitepress` and `bun` themes. Closes #69.
- Fixes two SPA-related listener leaks: `sidebar.stx` guards its document-level click handler with `window.__bpSidebarBound`, and `page-toc.stx` removes its prior scroll listener before re-binding on each init.

## Test plan
- [ ] `bun run typecheck` clean
- [ ] `bunx --bun pickier packages/bunpress/src` — only the two pre-existing warnings remain
- [ ] Dev server: `bunpress dev` and click through internal links, verify no full-document fetches in DevTools Network panel
- [ ] Back/forward navigation restores prior scroll position
- [ ] Cross-page hash links scroll to the right anchor on first nav and on subsequent SPA nav
- [ ] Mobile (<960px): hamburger opens drawer, backdrop closes it, body scroll locks while open, link click closes it
- [ ] Code block scrollbar styling matches the rest of the theme; tables hover correctly; dark-mode contrast acceptable
- [ ] Bun theme also picks up layout chrome (not just vitepress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)